### PR TITLE
[BUGFIX] TYPO3 7.5-dev compatibility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The created container should also keep running in detached mode:
 
 Install or update TYPO3 CMS dependencies to the pinned version in the repository:
 
-    docker exec -it  --user="webadmin" typo3 /bin/bash -c 'cd /var/www/typo3; composer install'
+    docker exec -it  --user="webadmin" typo3 /bin/bash -c 'cd /var/webadmin/typo3_src && rm -Rf vendor && composer install'
 
 Start MySQL:
 
@@ -118,7 +118,8 @@ Start Apache web server:
 
 Enable TYPO3's [install tool](https://docs.typo3.org/typo3cms/SecurityGuide/GuidelinesIntegrators/InstallTool/Index.html):
 
-    docker exec -it --user="www-data" typo3 touch /var/www/typo3/typo3conf/ENABLE_INSTALL_TOOL
+    docker exec -it --user="www-data" typo3 touch /var/www/typo3/typo3conf/ENABLE_INSTALL_TOOL # TYPO3 6.2
+    docker exec -it --user="www-data" typo3 touch /var/www/typo3/FIRST_INSTALL # TYPO3 7
 
 Get containers's IP adress:
 

--- a/typo3-debian-latest/Dockerfile
+++ b/typo3-debian-latest/Dockerfile
@@ -46,9 +46,7 @@ RUN echo "<?php\n\$GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']='en_US.UTF-
 RUN cd /var/www/typo3 && \
 ln -s ../../webadmin/typo3_src typo3_src && \
 ln -s typo3_src/index.php index.php && \
-ln -s typo3_src/typo3 typo3 && \
-ln -s typo3_src/composer.json && \
-ln -s typo3_src/composer.lock
+ln -s typo3_src/typo3 typo3
 
 # Give webadmin read and write access to DocumentRoot directory structure
 # This has no effect to files in the file share which are not mounted at this time.
@@ -110,6 +108,8 @@ RUN sed --in-place 's!/var/www/html!/var/www/typo3\
 \n\t\t\tphp_admin_value upload_max_filesize "10M"\
 \n\t\t\tphp_admin_value post_max_size "15M"\
 \n\t\t\tphp_admin_value max_execution_time "240"\
+\n\t\t\tphp_admin_value max_input_vars "1500"\
+\n\t\t\tphp_admin_value always_populate_raw_post_data "-1"\
 \n\t\t</IfModule>\
 \n\t</Directory>\
 !g' /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
- PHP ini: max_input_vars = 1500; always_populate_raw_post_data "-1";
- create file /var/www/typo3/FIRST_INSTALL
- remove composer symlink in /var/www/typo3, do composer install in /var/webadmin/typo3_src instead (delete vendor before)

Fixes #16
